### PR TITLE
Adds example to customize the color for a particular bar by its value

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -343,6 +343,25 @@ metadata = {
 }
 ```
 
+You can take it a step further and set a color to highlight one specific value in our data. In this example, we can highlight the year with the most arrests setting the `color-by-column` parameter to `True` and using the `color-category` parameter to set a color to the year 2010.
+
+```python
+"color-by-column": True,
+"color-category": {"map": {"2010": "#8e4e0a"}},
+```
+
+This customization would be set inside the metadata dictionary and would look like this.
+
+```python
+metadata = {
+    "visualize": {
+        "base-color": "#bf7836",  # Our accent color
+        "color-by-column": True,
+        "color-category": {"map": {"2010": "#8e4e0a"}},
+    }
+}
+```
+
 That can then be passed to the `update_chart` method of the `dw` object, which will apply the changes to the chart.
 
 ```python


### PR DESCRIPTION
Dug around to find the params for a customization that we use to highlight the bar for a specific value in a column or bar chart.

The example I added ot the docs shows how to customize a column's color by value using the `color-by-column` and `color-category` parameters.

```python
metadata = {
    "visualize": {
        "base-color": "#bf7836",  # Our accent color
        "color-by-column": True,
        "color-category": {"map": {"2010": "#8e4e0a"}},
    }
}
dw.update_chart(chart_id, metadata=metadata)
```

Example chart...
<img width="735" alt="image" src="https://github.com/user-attachments/assets/528a5536-cad3-4e10-a4a4-7b62d29fdeb9">