### PR TITLE
Upgrade sphinx-palewire-theme to 0.1.3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ sphinx-rtd-theme = "*"
 sphinxcontrib-mermaid = "*"
 myst-parser = "*"
 tomli = "*"
-sphinx-palewire-theme = "==0.0.18"
+sphinx-palewire-theme = "==0.1.3"
 
 [packages]
 exceptiongroup = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -2846,10 +2846,10 @@
         },
         "sphinx-palewire-theme": {
             "hashes": [
-                "sha256:f009e70d388f314c42c9a5cab9e5c7d8f8ea90ffe9acc10932cbcd6986ed105b"
+                "sha256:d02cfdc4b6f857de398477a85af4a7844c5eadfba252a632458ec1298e387ab8"
             ],
             "index": "pypi",
-            "version": "==0.0.18"
+            "version": "==0.1.3"
         },
         "sphinx-rtd-theme": {
             "hashes": [


### PR DESCRIPTION
Upgrade `sphinx-palewire-theme` to `0.1.3`.

Validation: Failed: installing locked develop/docs dependencies into seeded Python 3.11 venv exited 1. ╰─▶ Because myst-parser==4.0.1 depends on markdown-it-py>=3.0,<4.dev0 / and you require markdown-it-py==4.0.0, we can conclude that your / requirements and myst-parser==4.0.1 are incompatible. / And because you require myst-parser==4.0.1, we can conclude that your / requirements are unsatisfiable. Note: installing the combined locked default+develop set is unsatisfiable before docs build because the lock pins markdown-it-py==4.0.0 while myst-parser==4.0.1 requires markdown-it-py<4.

No unrelated changes included.